### PR TITLE
fix: github publish action updated

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install all dependencies
-        run: npm install
+        run: npm install --legacy-peer-deps
 
       - name: Build
         run: npm run build # The build command of your project

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npm run test


### PR DESCRIPTION
npm install command requires to install legacy deps, so it has been added to avoid upstream conflict

## Description
-  github publish action updated, workflow was throwing "upstream conflict exception" when running a job.

## Related Issues
- N/A