### PR TITLE
refactor: remove global.css which it no longer exists

### DIFF
--- a/gatsby-browser.ts
+++ b/gatsby-browser.ts
@@ -1,3 +1,2 @@
 import "./src/assets/scss/main.scss";
-import './src/styles/global.css'
 export { wrapRootElement } from "./internal/gatsby/wrap-root-element";


### PR DESCRIPTION
## Description

- [remove global.css which it no longer exists](https://github.com/edenilsonpineda/edenilsondev.com/commit/9173ba8f2ace4c12c38fb55371ade333c63cf649)

## Related Issues
- N/A